### PR TITLE
Fixed error when sending requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ class ResponseStream(object):
             self._bytes.seek(position, whence) 
 
 
-cookie = input("Paste the cookies: ")
+cookie = input("Paste the cookies: ").encode('latin-1', 'replace')
 
 isbn = input("Input the ISBN of the book you want to download: ")
 


### PR DESCRIPTION
After placing the cookie, the request returned the error below caused by the incorrect encoding of the cookie.

```
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2019' in position 517: ordinal not in range(256)
```